### PR TITLE
Add initial Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -180,3 +180,6 @@ at [https://www.contributor-covenant.org/translations][translations].
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
 
+# Deviations
+
+To see the deviations from the Contributor Covenant Code of Conduct version 2.1, please check the git history for this file, or manually create a diff.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -109,6 +109,12 @@ has not been handled appropriatly.
 
 > The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to coc-escalation@lists.openjsf.org. - https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#escalation
 
+## Privacy Expectations
+
+As per Code of Conduct requirements set out by the OpenJS Foundation, we will maintain the confidentiality with regard to the reporter of an incident.
+For the purposes of tracking between Code of Conduct review members, incidents may be tracked in a private organizational GitHub Repository.
+In addition to any Code of Conduct review team, GitHub organizational owners will have access to view details of reports by way of having full GitHub organizational admin access.
+
 ## Enforcement Guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -103,6 +103,12 @@ All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
+In addition, JSON Schema is in the process of joining the OpenJS Foundation.
+The OpenJS Foundation provides an escalation path should you feel your report
+has not been handled appropriatly.
+
+> The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to coc-escalation@lists.openjsf.org. - https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md#escalation
+
 ## Enforcement Guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,170 @@
+# JSON Schema Organizational Code of Conduct
+
+Our (The JSON Schema Organization) Code of Conduct is a combination of
+the "Contributor Covenant Code of Conduct" 2.1 and the IETF BCP 54 "IETF Guidelines for Conduct" (RFC7154).
+
+# IETF Guidelines for Conduct
+
+Note: These guidelines are not provided in full in this document.
+Some extracts are provided.
+Please see the [RFC document](https://www.rfc-editor.org/rfc/rfc7154.html) for full details.
+While we do not currently formally interact with the IETF beyond publication of specification documents,
+we have found their approach to developing specifications well informed and useful.
+
+This document provides a set of guidelines for personal interaction
+in the Internet Engineering Task Force.  The guidelines recognize the
+diversity of IETF participants, emphasize the value of mutual
+respect, and stress the broad applicability of our work.
+
+The work of the IETF relies on cooperation among a diverse range of
+people with different ideas and communication styles.  The IETF
+strives, through these guidelines for conduct, to create and maintain
+an environment in which every person is treated with dignity,
+decency, and respect.
+
+We dispute ideas by using reasoned argument rather than through
+intimidation or personal attack.
+
+The IETF puts its emphasis on technical
+competence, rough consensus, and individual participation, and it
+needs to be open to competent input from any source.
+
+IETF participants use their best engineering judgment to find the
+best solution for the whole Internet, not just the best solution
+for any particular network, technology, vendor, or user.
+
+Some thoughts on "consensus": https://datatracker.ietf.org/doc/html/rfc7282
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+report@jsonschema.dev.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # .github
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+
 A repo containing default GitHub community health files

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,5 @@
+# Architectural Decision Log
+
+Your ADR log is in another castle (or rather, another repository).
+
+Please use the ADRs found in the [Community](https://github.com/json-schema-org/community) repo for this .github repo.


### PR DESCRIPTION
Majority of work in relation to Adopt a Code of Conduct for JSON Schema (https://github.com/json-schema-org/community/issues/26).

- Contributor Covenant CoC added
- Extracts from IETF BCP 54 added and linked
- Note about escalation via OpenJSF
- Note about privacy expectations