### PR TITLE
Update SUPPORT.md - Add website

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,6 @@
-There are several ways to communicate with the JSON Schema Community to get support:
+There are several ways to get support and communicate with the JSON Schema Community:
 
+* JSON Schema Website's [getting started guide](https://json-schema.org/learn) and documentation.
 * GitHub issues - for bugs and feature requests.
 * [GitHub discussions](https://github.com/orgs/json-schema-org/discussions) - for questions, proposals and ideas.
 * GitHub pull requests (PRs) - for fixes or new features already discussed under GitHub issues.


### PR DESCRIPTION
Add getting started guide and docs to the list of support options.

I noticed the [contributing guidelines in the repo template](https://github.com/json-schema-org/repo-template/blob/6a5dbe8bb208c32deaa01bf4c6d755b0e0c474be/CONTRIBUTING.md) suggested the website, and as I'm looking to make another PR to simply redirect people to the support file in this repo, I figured that made most sense.